### PR TITLE
update stash creation to newer api

### DIFF
--- a/files/default/handlers/sensu_handlers.rb
+++ b/files/default/handlers/sensu_handlers.rb
@@ -12,17 +12,22 @@ class Chef
         end
 
         def silence_client(client, timeout)
-          req = Net::HTTP::Post.new("/stash/silence/#{client}", {'Content-Type' => 'application/json'})
+          req = Net::HTTP::Post.new("/stashes", {'Content-Type' => 'application/json'})
           now = Time.now.to_i
 
+          payload = {
+            'path' => "silence/#{client}",
+            'content' => {
+              'timestamp' => now,
+              'owner' => 'chef'
+            }
+          }
+
           if timeout.is_a?(Fixnum)
-            expires = now + timeout
-            payload = { 'timestamp' => now, 'owner' => 'chef', 'expires' => expires }.to_json
-          else
-            payload = { 'timestamp' => now, 'owner' => 'chef' }.to_json
+            payload = payload.merge({ 'expire' => timeout })
           end
 
-          req.body = payload
+          req.body = payload.to_json
 
           begin
             Net::HTTP.start(@uri.host, @uri.port) do |http|


### PR DESCRIPTION
We've been using the old (~ 0.10) API for creating stashes, i.e. posting directly to /stash/silence/foo instead of the new method which includes the path as part of the JSON posted to /stashes. 

The old approach also depended on an external check to come by and clean up expired stashes. As of 0.12, Sensu offers automatic stash expiration which this change will take advantage of.

Should take care of #1 I think?
